### PR TITLE
Csv/BOM Fix

### DIFF
--- a/src/ladb_toolbox/ruby/controller/cutlist_controller.rb
+++ b/src/ladb_toolbox/ruby/controller/cutlist_controller.rb
@@ -403,13 +403,15 @@ module Ladb
               case encoding.to_i
                 when EXPORT_OPTION_ENCODING_UTF16LE
                   with_bom = true
-                  encoding = 'UTF-16LE:UTF-8'
+                  bom = "\xFE\xFF".force_encoding('utf-16le')
+                  encoding = ':UTF-16LE:UTF-8'
                 else
-                  with_bom = false
-                  encoding = 'UTF-8'
+                  with_bom = true
+                  bom = "\xEF\xBB\xBF"
+                  encoding = ':UTF-8'
               end
 
-              File.open(export_path, "w+#{encoding}") do |f|
+              File.open(export_path, "wb+#{encoding}") do |f|
                 csv_file = CSV.generate({ :col_sep => col_sep, :force_quotes => force_quotes }) do |csv|
 
                   # Header row
@@ -465,7 +467,7 @@ module Ladb
 
                 # Write file
                 if with_bom
-                  f.write "\xEF\xBB\xBF" # UTF-8 Byte Order Mark
+                  f.write(bom)
                 end
                 f.write(csv_file)
 

--- a/src/ladb_toolbox/ruby/controller/cutlist_controller.rb
+++ b/src/ladb_toolbox/ruby/controller/cutlist_controller.rb
@@ -25,6 +25,7 @@ module Ladb
 
       EXPORT_OPTION_ENCODING_UTF8 = 0
       EXPORT_OPTION_ENCODING_UTF16LE = 1
+      EXPORT_OPTION_ENCODING_UTF16BE = 2
 
       def initialize(plugin)
         super(plugin, 'cutlist')
@@ -403,8 +404,12 @@ module Ladb
               case encoding.to_i
                 when EXPORT_OPTION_ENCODING_UTF16LE
                   with_bom = true
-                  bom = "\xFE\xFF".force_encoding('utf-16le')
-                  encoding = ':UTF-16LE:UTF-8'
+                  bom = "\xFF\xFE".force_encoding('utf-16le')
+                  encoding = ':UTF-16LE'
+                when EXPORT_OPTION_ENCODING_UTF16BE
+                  with_bom = true
+                  bom = "\xFE\xFF".force_encoding('utf-16be')
+                  encoding = ':UTF-16BE'
                 else
                   with_bom = true
                   bom = "\xEF\xBB\xBF"


### PR DESCRIPTION
CSV export did not work for me because of the missing ":" in front. Changed so that file is written in binary and BOM is always added. 

Caveat: Interface option is missing, I did not add it.